### PR TITLE
Fix typo of delete-yatai.sh

### DIFF
--- a/delete-yatai.sh
+++ b/delete-yatai.sh
@@ -4,7 +4,7 @@
 helm uninstall yatai -n yatai-system
 
 # Remove additional yatai related namespaces
-kubectl delete namesapce yatai-components
+kubectl delete namespace yatai-components
 kubectl delete namespace yatai-operators
 kubectl delete namespace yatai-builders
 kubectl delete namespace yatai


### PR DESCRIPTION
Fix typo 
`kubectl delete namesapce yatai-components` 
-> `kubectl delete namespace yatai-components` 