### PR TITLE
Fix/postgres-variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,12 @@ There are many ways to contribute to the project:
 - Report issues you're facing and "Thumbs up" on issues and feature requests that are relevant to you.
 - Investigate bugs and reviewing other developer's pull requests.
 - Contributing code or documentation to the project by submitting a Github pull request.
+
+
+# Testing
+
+## Unit Tests
+
+Uses: https://github.com/quintush/helm-unittest to unit test each yaml file
+
+run using: `helm unittest -3 .`

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -137,3 +137,17 @@ Generate inititalization token
     {{- $secretData := (get $secretObj "data") | default dict }}
     {{- (get $secretData "initialization_token") | default (randAlphaNum 16 | nospace | b64enc) | b64dec }}
 {{- end -}}
+
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "yatai.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "yatai.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -115,16 +115,16 @@ Add environment variables to configure database values
 */}}
 {{- define "yatai.postgresql.existingsecret.key" -}}
 {{- if .Values.postgresql.enabled -}}
-    {{- printf "%s" "postgresql-password" -}}
+    {{- printf "%s" "PG_PASSWORD" -}}
 {{- else -}}
     {{- if .Values.externalPostgresql.existingSecret -}}
         {{- if .Values.externalPostgresql.existingSecretPasswordKey -}}
             {{- printf "%s" .Values.externalPostgresql.existingSecretPasswordKey -}}
         {{- else -}}
-            {{- printf "%s" "postgresql-password" -}}
+            {{- printf "%s" "PG_PASSWORD" -}}
         {{- end -}}
     {{- else -}}
-        {{- printf "%s" "postgresql-password" -}}
+        {{- printf "%s" "PG_PASSWORD" -}}
     {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -33,11 +33,12 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - sh
-            - -c
-          args:
-            - exec /app/api-server serve -c /conf/config.yaml
+          {{- if .Values.command }}
+          command: {{- include "yatai.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args: {{- include "yatai.render" (dict "value" .Values.args "context" $) | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 7777
@@ -49,13 +50,13 @@ spec:
               value: {{ ternary .Values.postgresql.postgresqlDatabase .Values.externalPostgresql.database .Values.postgresql.enabled }}
             - name: PG_PORT
               value: {{ ternary "5432" .Values.externalPostgresql.port .Values.postgresql.enabled | quote}}
+            - name: PG_USER
+              value: {{ ternary .Values.postgresql.postgresqlUsername .Values.externalPostgresql.user .Values.postgresql.enabled | quote }}
             - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "yatai.postgresql.secretName" . }}
                   key: {{ include "yatai.postgresql.existingsecret.key" . }}
-            - name: PG_USER
-              value: {{ ternary .Values.postgresql.postgresqlUsername .Values.externalPostgresql.user .Values.postgresql.enabled | quote }}
             - name: SESSION_SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -1,0 +1,121 @@
+suite: test deployment
+templates:
+  - deployment.yaml
+tests:
+  - it: renders with defaults
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].command[0]
+          value: sh
+      - equal:
+          path: spec.template.spec.containers[0].command[1]
+          value: -c
+      - equal:
+          path: spec.template.spec.containers[0].args[0]
+          value: exec /app/api-server serve -c /conf/config.yaml
+  - it: custom command and args
+    set: 
+      command:
+        - thing
+        - thing 2
+      args:
+        - testing arguments
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].command[0]
+          value: thing
+      - equal:
+          path: spec.template.spec.containers[0].command[1]
+          value: thing 2
+      - equal:
+          path: spec.template.spec.containers[0].args[0]
+          value: testing arguments
+  - it: enable postgres
+    set: 
+      postgresql.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: PG_HOST
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: RELEASE-NAME-postgresql
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: PG_DATABASE
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: yatai
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: PG_PORT
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: "5432"
+      - equal:
+          path: spec.template.spec.containers[0].env[3].name
+          value: PG_USER
+      - equal:
+          path: spec.template.spec.containers[0].env[3].value
+          value: postgres
+      - equal:
+          path: spec.template.spec.containers[0].env[4].name
+          value: PG_PASSWORD
+      - equal:
+          path: spec.template.spec.containers[0].env[4].valueFrom.secretKeyRef.name
+          value: RELEASE-NAME-postgresql
+      - equal:
+          path: spec.template.spec.containers[0].env[4].valueFrom.secretKeyRef.key
+          value: postgresql-password
+  - it: external postgres
+    set: 
+      postgresql.enabled: false
+      externalPostgresql:
+        host: test-host
+        database: test-db
+        port: 1234
+        user: test-user
+        existingSecret: test-secret
+        existingSecretPasswordKey: PG_PASSWORD
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: PG_HOST
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: test-host
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: PG_DATABASE
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: test-db
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: PG_PORT
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: "1234"
+      - equal:
+          path: spec.template.spec.containers[0].env[3].name
+          value: PG_USER
+      - equal:
+          path: spec.template.spec.containers[0].env[3].value
+          value: test-user
+      - equal:
+          path: spec.template.spec.containers[0].env[4].name
+          value: PG_PASSWORD
+      - equal:
+          path: spec.template.spec.containers[0].env[4].valueFrom.secretKeyRef.name
+          value: test-secret
+      - equal:
+          path: spec.template.spec.containers[0].env[4].valueFrom.secretKeyRef.key
+          value: PG_PASSWORD

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -72,7 +72,7 @@ tests:
           value: RELEASE-NAME-postgresql
       - equal:
           path: spec.template.spec.containers[0].env[4].valueFrom.secretKeyRef.key
-          value: postgresql-password
+          value: PG_PASSWORD
   - it: external postgres
     set: 
       postgresql.enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -6,6 +6,12 @@ replicaCount: 1
 
 registry: quay.io/bentoml
 
+command:
+  - sh
+  - -c
+args:
+  - exec /app/api-server serve -c /conf/config.yaml
+
 image:
   repository: yatai
   pullPolicy: IfNotPresent


### PR DESCRIPTION
using postgres-password as a key doesn't make much sense. It isn't a valid ENV variable, and there is a perfectly good one from the standard of PG_PASSWORD